### PR TITLE
Using i2c-dev API (smbus still available via #ifdef). Use enums where…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A C++ driver for the MCP23017 (I2C GPIO expander chip)
 
 https://www.microchip.com/wwwproducts/en/MCP23017
 
-Built for Jetson Xavier (though with minor changes, it should be possible to adapt it to other Linux systems which use the i2c-dev library)
+Originally developed for Jetson Xavier using the smbus interface, it also works on systems with i2c-dev (via #define in src/MCP23017.cpp).
 
 The code is mainly a port of the Adafruit MCP23017 Arduino library, with the I2C command code from the Jetsonhacks PCA9685 PWM driver:
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,2 +1,4 @@
-all:
-	g++ button.cpp ../src/MCP23017.cpp -I../src -li2c -o button
+i2c-dev:
+	g++ button.cpp ../src/MCP23017.cpp -I../src -o button-i2c-dev
+smbus:
+	g++ -D USE_SMBUS button.cpp ../src/MCP23017.cpp -I../src -o button-smbus

--- a/example/button.cpp
+++ b/example/button.cpp
@@ -5,15 +5,15 @@
 using namespace std;
 
 //constants set to emulate Arduino pin parameters
-#define HIGH 1
-#define LOW 0
+constexpr MCP23017::Level HIGH = MCP23017::HIGH;
+constexpr MCP23017::Level LOW = MCP23017::LOW;
 
-#define INPUT 1
-#define OUTPUT 0
+constexpr MCP23017::Direction INPUT = MCP23017::INPUT;
+constexpr MCP23017::Direction OUTPUT = MCP23017::OUTPUT;
 
-#define CHANGE 0
-#define FALLING 1
-#define RISING 2
+constexpr MCP23017::InterruptMode CHANGE = MCP23017::CHANGE;
+constexpr MCP23017::InterruptMode FALLING = MCP23017::FALLING;
+constexpr MCP23017::InterruptMode RISING = MCP23017::RISING;
 
 // Basic pin reading and pullup test for the MCP23017 I/O expander
 // public domain!
@@ -30,9 +30,13 @@ using namespace std;
 
 int main() {
 
-  MCP23017 mcp(8, 0x20);      // use default address 0x20
+  MCP23017 mcp(8, MCP23017::DEFAULT_ADDRESS);      // use default address 0x20
 
-  cout << mcp.openI2C() << "\n";
+  if(!mcp.openI2C())
+  {
+    cerr << "Error opening device\n";
+    return 1;
+  }
 
 
   mcp.pinMode(0, INPUT);

--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -1,8 +1,61 @@
-#include <MCP23017.h>
+#include "MCP23017.h"
+
+//#define USE_SMBUS // if undefined, uses i2c-dev
+#ifdef USE_SMBUS
+extern "C" {
+#include <i2c/smbus.h>
+}
+#else // USE_SMBUS
+#include <linux/i2c-dev.h>
+// heuristic to guess what version of i2c-dev.h we have:
+#ifndef I2C_SMBUS_BLOCK_MAX
+// If this is not defined, we have the "stock" i2c-dev.h
+// so we include linux/i2c.h
+#include <linux/i2c.h>
+typedef unsigned char i2c_char_t;
+#else
+typedef char i2c_char_t;
+#endif
+#endif // USE_SMBUS
+
+#include <linux/i2c-dev.h>
+#include <sys/ioctl.h>
+#include <cstdlib>
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+// registers
+#define MCP23017_IODIRA 0x00
+#define MCP23017_IPOLA 0x02
+#define MCP23017_GPINTENA 0x04
+#define MCP23017_DEFVALA 0x06
+#define MCP23017_INTCONA 0x08
+#define MCP23017_IOCONA 0x0A
+#define MCP23017_GPPUA 0x0C
+#define MCP23017_INTFA 0x0E
+#define MCP23017_INTCAPA 0x10
+#define MCP23017_GPIOA 0x12
+#define MCP23017_OLATA 0x14
 
 
- MCP23017::MCP23017(int bus, int address) {
-    kI2CBus = bus;           // I2C bus of Jetson (1 and 8 available on Xavier)
+#define MCP23017_IODIRB 0x01
+#define MCP23017_IPOLB 0x03
+#define MCP23017_GPINTENB 0x05
+#define MCP23017_DEFVALB 0x07
+#define MCP23017_INTCONB 0x09
+#define MCP23017_IOCONB 0x0B
+#define MCP23017_GPPUB 0x0D
+#define MCP23017_INTFB 0x0F
+#define MCP23017_INTCAPB 0x11
+#define MCP23017_GPIOB 0x13
+#define MCP23017_OLATB 0x15
+
+#define MCP23017_INT_ERR 255
+
+MCP23017::MCP23017(int bus, int address) {
+    kI2CBus = bus;           // I2C bus
     kI2CAddress = address ; // Address of MCP23017; defaults to 0x20
     error = 0 ;
 }
@@ -87,9 +140,42 @@ uint8_t MCP23017::regForPin(uint8_t pin, uint8_t portAaddr, uint8_t portBaddr){
  */
 uint8_t MCP23017::readRegister(uint8_t addr)
 {
+#ifdef USE_SMBUS
     int toReturn = i2c_smbus_read_byte_data(kI2CFileDescriptor, addr);
+#else // USE_SMBUS
+    uint8_t i2C_address = kI2CAddress;
+    int i2C_file = kI2CFileDescriptor;
+    unsigned int reg = addr;
+
+    i2c_char_t inbuf, outbuf;
+    struct i2c_rdwr_ioctl_data packets;
+    struct i2c_msg messages[2];
+
+    /* Reading a register involves a repeated start condition which needs ioctl() */
+    outbuf = reg;
+    messages[0].addr  = i2C_address;
+    messages[0].flags = 0;
+    messages[0].len   = sizeof(outbuf);
+    messages[0].buf   = &outbuf;
+
+    /* The data will get returned in this structure */
+    messages[1].addr  = i2C_address;
+    messages[1].flags = I2C_M_RD/* | I2C_M_NOSTART*/;
+    messages[1].len   = sizeof(inbuf);
+    messages[1].buf   = &inbuf;
+
+    /* Send the request to the kernel and get the result back */
+    packets.msgs      = messages;
+    packets.nmsgs     = 2;
+    int toReturn;
+    if(ioctl(i2C_file, I2C_RDWR, &packets) < 0) {
+        toReturn = -1;
+    } else {
+        toReturn = inbuf;
+    }
+#endif // USE_SMBUS
     if (toReturn < 0) {
-        printf("MCP23017 Read Byte error: %d",errno) ;
+        printf("MCP23017 Read Byte error: %d\n",errno) ;
         error = errno ;
         toReturn = -1 ;
     }
@@ -105,14 +191,26 @@ uint8_t MCP23017::writeRegister(uint8_t addr, uint8_t writeValue)
 {   // For debugging:
     // printf("Wrote: 0x%02X to register 0x%02X \n",writeValue, writeRegister) ;
 
+#ifdef USE_SMBUS
     int toReturn = i2c_smbus_write_byte_data(kI2CFileDescriptor, addr, writeValue);
+#else // USE_SMBUS
+    unsigned int reg = addr;
+    unsigned int value = writeValue;
+    int i2C_file = kI2CFileDescriptor;
+    char buf[2] = { static_cast<char>(reg & 0xFF), static_cast<char>(value & 0xFF) };
+    errno = 0; // to avoid ambiguity in the error message in case write() returns 0
+    int toReturn;
+    if(write(i2C_file, buf, 2) != sizeof(buf))
+        toReturn = -1;
+    else
+        toReturn = 0;
+#endif // USE_SMBUS
     if (toReturn < 0) {
         perror("Write to I2C Device failed");
         error = errno ;
         toReturn = -1 ;
     }
     return toReturn ;
-
 }
 
 /**
@@ -120,7 +218,14 @@ uint8_t MCP23017::writeRegister(uint8_t addr, uint8_t writeValue)
  */
 uint8_t MCP23017::readByte()
 {
+#ifdef USE_SMBUS
     int toReturn = i2c_smbus_read_byte(kI2CFileDescriptor);
+#else // USE_SMBUS
+    i2c_char_t byte;
+    int toReturn = read(kI2CFileDescriptor, &byte, sizeof(byte));
+    if(sizeof(byte) == toReturn)
+        toReturn = byte;
+#endif // USE_SMBUS
     if (toReturn < 0) {
         printf("MCP23017 Read Byte error: %d",errno) ;
         error = errno ;
@@ -137,7 +242,16 @@ uint8_t MCP23017::readByte()
 uint8_t MCP23017::writeByte(uint8_t writeValue)
 {   // For debugging:
     // printf("Wrote: 0x%02X to register 0x%02X \n",writeValue, writeRegister) ;
+#ifdef USE_SMBUS
     int toReturn = i2c_smbus_write_byte(kI2CFileDescriptor, writeValue);
+#else // USE_SMBUS
+    errno = 0; // to avoid ambiguity in the error message in case write() returns 0
+    int toReturn = write(kI2CFileDescriptor, &writeValue, sizeof(writeValue));
+    if(toReturn == sizeof(writeValue))
+        toReturn = 0;
+    else
+        toReturn = -1;
+#endif // USE_SMBUS
     if (toReturn < 0) {
         printf("MCP23017 Write Byte error: %d",errno) ;
         error = errno ;
@@ -166,7 +280,7 @@ void MCP23017::updateRegisterBit(uint8_t pin, uint8_t pValue, uint8_t portAaddr,
 /**
  * Sets the pin mode to either INPUT or OUTPUT
  */
-void MCP23017::pinMode(uint8_t p, uint8_t d) {
+void MCP23017::pinMode(uint8_t p, Direction d) {
 	updateRegisterBit(p,(d==INPUT),MCP23017_IODIRA,MCP23017_IODIRB);
 }
 
@@ -234,7 +348,7 @@ void MCP23017::digitalWrite(uint8_t pin, uint8_t d) {
 	writeRegister(regAddr,gpio);
 }
 
-void MCP23017::pullUp(uint8_t p, uint8_t d) {
+void MCP23017::pullUp(uint8_t p, Level d) {
 	updateRegisterBit(p,d,MCP23017_GPPUA,MCP23017_GPPUB);
 }
 
@@ -253,7 +367,7 @@ bool MCP23017::digitalRead(uint8_t pin) {
  * If you are connecting the INTA/B pin to arduino 2/3, you should configure the interupt handling as FALLING with
  * the default configuration.
  */
-void MCP23017::setupInterrupts(uint8_t mirroring, uint8_t openDrain, uint8_t polarity){
+void MCP23017::setupInterrupts(bool mirroring, bool openDrain, Level polarity){
 	// configure the port A
 	uint8_t ioconfValue=readRegister(MCP23017_IOCONA);
 	bitWrite(ioconfValue,6,mirroring);
@@ -276,7 +390,7 @@ void MCP23017::setupInterrupts(uint8_t mirroring, uint8_t openDrain, uint8_t pol
  * that caused the interrupt or you read the port itself. Check the datasheet can be confusing.
  *
  */
-void MCP23017::setupInterruptPin(uint8_t pin, uint8_t mode) {
+void MCP23017::setupInterruptPin(uint8_t pin, InterruptMode mode) {
 
 	// set the pin interrupt control (0 means change, 1 means compare against given value);
 	updateRegisterBit(pin,(mode!=CHANGE),MCP23017_INTCONA,MCP23017_INTCONB);

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -1,54 +1,50 @@
-#ifndef _MCP23017_H
-#define _MCP23017_H
-
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
 
-extern "C" {
-#include <i2c/smbus.h>
-}
-
-#include <linux/i2c-dev.h>
-#include <sys/ioctl.h>
-#include <cstdlib>
-#include <cstdio>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-
-
-
 class MCP23017
 {
 public:
+    typedef enum {
+        CHANGE = 0,
+        FALLING = 1,
+        RISING = 2,
+    } InterruptMode;
+    typedef enum {
+        LOW = 0,
+        HIGH = 1,
+    } Level;
+    typedef enum {
+        INPUT = 0,
+        OUTPUT = 1,
+    } Direction;
+
+    enum { DEFAULT_ADDRESS = 0x20 };
     unsigned char kI2CBus ;         // I2C bus of the MCP23017
     int kI2CFileDescriptor ;        // File Descriptor to the MCP23017
     int kI2CAddress ;               // Address of MCP23017; defaults to 0x20
     int error ;
-    MCP23017(int bus=1, int address=0x20);
+    MCP23017(int bus=1, int address=DEFAULT_ADDRESS);
     ~MCP23017() ;
     bool openI2C() ;
     void closeI2C();
 
-
-    void pinMode(uint8_t p, uint8_t d);
+    void pinMode(uint8_t p, Direction d);
     void digitalWrite(uint8_t p, uint8_t d);
-    void pullUp(uint8_t p, uint8_t d);
+    void pullUp(uint8_t p, Level d);
     bool digitalRead(uint8_t p);
 
     void writeGPIOAB(uint16_t);
     uint16_t readGPIOAB();
     uint8_t readGPIO(uint8_t b);
 
-    void setupInterrupts(uint8_t mirroring, uint8_t open, uint8_t polarity);
-    void setupInterruptPin(uint8_t p, uint8_t mode);
+    void setupInterrupts(bool mirroring, bool open, Level polarity);
+    void setupInterruptPin(uint8_t p, InterruptMode mode);
     uint8_t getLastInterruptPin();
     uint8_t getLastInterruptPinValue();
 
 private:
-    uint8_t i2caddr;
-
     uint8_t bitForPin(uint8_t pin);
     uint8_t regForPin(uint8_t pin, uint8_t portAaddr, uint8_t portBaddr);
 
@@ -65,49 +61,4 @@ private:
 
     bool bitRead(uint8_t num, uint8_t index);
     void bitWrite(uint8_t &var, uint8_t index, uint8_t bit);
-
-
 };
-
-#define MCP23017_ADDRESS 0x20
-
-// registers
-#define MCP23017_IODIRA 0x00
-#define MCP23017_IPOLA 0x02
-#define MCP23017_GPINTENA 0x04
-#define MCP23017_DEFVALA 0x06
-#define MCP23017_INTCONA 0x08
-#define MCP23017_IOCONA 0x0A
-#define MCP23017_GPPUA 0x0C
-#define MCP23017_INTFA 0x0E
-#define MCP23017_INTCAPA 0x10
-#define MCP23017_GPIOA 0x12
-#define MCP23017_OLATA 0x14
-
-
-#define MCP23017_IODIRB 0x01
-#define MCP23017_IPOLB 0x03
-#define MCP23017_GPINTENB 0x05
-#define MCP23017_DEFVALB 0x07
-#define MCP23017_INTCONB 0x09
-#define MCP23017_IOCONB 0x0B
-#define MCP23017_GPPUB 0x0D
-#define MCP23017_INTFB 0x0F
-#define MCP23017_INTCAPB 0x11
-#define MCP23017_GPIOB 0x13
-#define MCP23017_OLATB 0x15
-
-#define MCP23017_INT_ERR 255
-
-//constants set up to emulate Arduino pin parameters
-#define HIGH 1
-#define LOW 0
-
-#define INPUT 1
-#define OUTPUT 0
-
-#define CHANGE 0
-#define FALLING 1
-#define RISING 2
-
-#endif


### PR DESCRIPTION
… appropriate. Removed #defines from header file to avoid clashes (among other things)

Tested on BeagleBone Black